### PR TITLE
fix(seo): align robots and sitemap with production domain

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://sergio-site.vercel.app/sitemap.xml
+
+Sitemap: https://sergio-site-drab.vercel.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://sergio-site.vercel.app/</loc>
+    <loc>https://sergio-site-drab.vercel.app/</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://sergio-site.vercel.app/about.html</loc>
+    <loc>https://sergio-site-drab.vercel.app/about.html</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://sergio-site.vercel.app/projects.html</loc>
+    <loc>https://sergio-site-drab.vercel.app/projects.html</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://sergio-site.vercel.app/contact.html</loc>
+    <loc>https://sergio-site-drab.vercel.app/contact.html</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
## Summary
Aligns `robots.txt` and `sitemap.xml` with the current production domain.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Why
The sitemap and robots configuration pointed to an incorrect Vercel domain, which could cause search engines to index the wrong URLs.

## How
- Updated `robots.txt` to reference the correct production sitemap.
- Updated all sitemap `<loc>` entries to use `https://sergio-site-drab.vercel.app`.
- Kept existing valid routes unchanged.

## Verification
- [x] `npm run ci:test` passes
- [x] `git diff` reviewed
- [x] No unrelated files modified

## Notes
Clean URLs are not implemented yet, so the sitemap keeps `.html` routes for existing pages.
