### PR TITLE
fix(security): add base vercel headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds base security headers for the static site through Vercel configuration.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Why
The production site did not define explicit HTTP security headers. This PR adds a minimal safe baseline without introducing CSP yet, avoiding risk of breaking fonts, scripts, partials, or forms.

## How
- Added `vercel.json`
- Applied headers globally:
  - `X-Frame-Options: DENY`
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`

## Verification
- [x] `npm run ci:test` passes
- [x] `git diff` reviewed
- [x] No unrelated files modified

## Notes
CSP is intentionally deferred to a separate PR.