### PR TITLE
fix(seo): add canonical and social metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Sobre Sergio Delgado: Ingeniero Civil Industrial enfocado en QA Automation, Data (Python/SQL), CI/CD y transformación digital con IA aplicada.">
   <title>Sobre mí — Sergio Delgado</title>
+  <link rel="canonical" href="https://sergio-site-drab.vercel.app/about.html">
+  <meta property="og:title" content="Sobre Sergio Delgado — QA, Datos y Sistemas">
+  <meta property="og:description" content="Perfil profesional de Sergio Delgado en QA, datos y transformación digital.">
+  <meta property="og:url" content="https://sergio-site-drab.vercel.app/about.html">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Contacta a Sergio Delgado para colaborar en proyectos de QA Automation, transformación digital con IA, análisis de datos y diseño de sistemas culturales en red.">
   <title>Contacto — Sergio Delgado</title>
+  <link rel="canonical" href="https://sergio-site-drab.vercel.app/contact.html">
+  <meta property="og:title" content="Contacto — Sergio Delgado">
+  <meta property="og:description" content="Contacto profesional para colaboraciones en QA, datos y sistemas.">
+  <meta property="og:url" content="https://sergio-site-drab.vercel.app/contact.html">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sergio Delgado — QA Automation, Data y transformación digital</title>
   <meta name="description" content="Portafolio de Sergio Delgado: QA Automation, Data (Python/SQL), CI/CD y transformación digital con IA aplicada. Proyectos reales en AG RBB y el universo Xexe Quantum.">
+  <link rel="canonical" href="https://sergio-site-drab.vercel.app/">
+  <meta property="og:title" content="Sergio Delgado — QA, Datos y Sistemas">
+  <meta property="og:description" content="Ingeniería aplicada a datos, QA y sistemas complejos.">
+  <meta property="og:url" content="https://sergio-site-drab.vercel.app/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">

--- a/projects.html
+++ b/projects.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Proyectos — Sergio Delgado</title>
   <meta name="description" content="Proyectos de Sergio Delgado: QA Automation, Data, gobernanza digital y el laboratorio narrativo Xexe Quantum.">
+  <link rel="canonical" href="https://sergio-site-drab.vercel.app/projects.html">
+  <meta property="og:title" content="Proyectos — Sergio Delgado">
+  <meta property="og:description" content="Proyectos de Sergio Delgado en QA, datos y sistemas.">
+  <meta property="og:url" content="https://sergio-site-drab.vercel.app/projects.html">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
Adds canonical URLs and basic social metadata to all static pages.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Why
Pages lacked canonical and social metadata, leading to potential duplicate indexing and poor link previews when shared.

## How
- Added canonical link per page
- Added Open Graph tags (title, description, url, type)
- Added twitter:card
- No changes to content, styles or scripts

## Verification
- [x] `npm run ci:test` passes
- [x] Manual review in browser
- [x] No breaking changes

## Notes
Uses minimal metadata; richer social cards can be added later.
