### PR TITLE
fix(frontend): add fallback for partials

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,7 +18,16 @@
   <link rel="icon" href="/favicon.ico">
 </head>
 <body>
-  <div data-include="nav"></div>
+  <div data-include="nav">
+    <nav class="container nav" aria-label="Navegación principal">
+      <a class="logo" href="index.html" data-nav="index">Sergio Delgado</a>
+      <ul class="menu">
+        <li><a href="about.html" data-nav="about">Sobre mí</a></li>
+        <li><a href="projects.html" data-nav="projects">Proyectos</a></li>
+        <li><a href="contact.html" data-nav="contact">Contacto</a></li>
+      </ul>
+    </nav>
+  </div>
   <main id="main" class="container">
     <h1>Sobre mí</h1>
 
@@ -51,7 +60,11 @@
     </p>
   </main>
 
-  <div data-include="footer"></div>
+  <div data-include="footer">
+    <footer class="container footer">
+      <p class="muted">© <span id="year"></span> Sergio Delgado</p>
+    </footer>
+  </div>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -18,7 +18,16 @@
   <link rel="icon" href="/favicon.ico">
 </head>
 <body>
-  <div data-include="nav"></div>
+  <div data-include="nav">
+    <nav class="container nav" aria-label="Navegación principal">
+      <a class="logo" href="index.html" data-nav="index">Sergio Delgado</a>
+      <ul class="menu">
+        <li><a href="about.html" data-nav="about">Sobre mí</a></li>
+        <li><a href="projects.html" data-nav="projects">Proyectos</a></li>
+        <li><a href="contact.html" data-nav="contact">Contacto</a></li>
+      </ul>
+    </nav>
+  </div>
 
   <main id="main" class="container">
     <h1>Contacto</h1>
@@ -43,7 +52,11 @@
     </form>
   </main>
 
-  <div data-include="footer"></div>
+  <div data-include="footer">
+    <footer class="container footer">
+      <p class="muted">© <span id="year"></span> Sergio Delgado</p>
+    </footer>
+  </div>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,16 @@
   <link rel="icon" href="/favicon.ico">
 </head>
 <body>
-  <div data-include="nav"></div>
+  <div data-include="nav">
+    <nav class="container nav" aria-label="Navegación principal">
+      <a class="logo" href="index.html" data-nav="index">Sergio Delgado</a>
+      <ul class="menu">
+        <li><a href="about.html" data-nav="about">Sobre mí</a></li>
+        <li><a href="projects.html" data-nav="projects">Proyectos</a></li>
+        <li><a href="contact.html" data-nav="contact">Contacto</a></li>
+      </ul>
+    </nav>
+  </div>
 
   <main id="main" class="container">
     <section class="hero">
@@ -49,7 +58,11 @@
     </section>
   </main>
 
-  <div data-include="footer"></div>
+  <div data-include="footer">
+    <footer class="container footer">
+      <p class="muted">© <span id="year"></span> Sergio Delgado</p>
+    </footer>
+  </div>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -68,15 +68,21 @@
         const name = node.getAttribute("data-include");
         if (!name) return;
 
-        // partials viven en la raíz del sitio: /partials/nav.html, /partials/footer.html
+        const fallbackHtml = node.innerHTML;
         const partialUrl = urlFromBase(`partials/${name}.html`);
 
-        const res = await fetch(partialUrl, { cache: "no-cache" });
-        if (!res.ok) {
-          node.innerHTML = "";
-          return;
+        try {
+          const res = await fetch(partialUrl, { cache: "no-cache" });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+          const html = await res.text();
+          if (!html.trim()) throw new Error("partial vacio");
+
+          node.innerHTML = html;
+        } catch (error) {
+          console.warn(`[partials] No se pudo cargar "${name}" desde ${partialUrl}. Se usa fallback local.`, error);
+          node.innerHTML = fallbackHtml;
         }
-        node.innerHTML = await res.text();
       })
     );
 
@@ -89,7 +95,7 @@
   document.addEventListener("DOMContentLoaded", () => {
     includePartials();
 
-    // Fallback por si una página no usa partials:
+    // Fallback por si una pagina no usa partials:
     setYear();
     bindContactForm();
   });

--- a/projects.html
+++ b/projects.html
@@ -20,7 +20,16 @@
 <body>
 
   <!-- NAV -->
-  <div data-include="nav"></div>
+  <div data-include="nav">
+    <nav class="container nav" aria-label="Navegación principal">
+      <a class="logo" href="index.html" data-nav="index">Sergio Delgado</a>
+      <ul class="menu">
+        <li><a href="about.html" data-nav="about">Sobre mí</a></li>
+        <li><a href="projects.html" data-nav="projects">Proyectos</a></li>
+        <li><a href="contact.html" data-nav="contact">Contacto</a></li>
+      </ul>
+    </nav>
+  </div>
 
   <main id="main" class="container">
     <h1>Proyectos</h1>
@@ -151,7 +160,11 @@
   </main>
 
   <!-- FOOTER -->
-  <div data-include="footer"></div>
+  <div data-include="footer">
+    <footer class="container footer">
+      <p class="muted">© <span id="year"></span> Sergio Delgado</p>
+    </footer>
+  </div>
 
   <script src="js/script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
Adds fallback HTML for navigation and footer partials, and improves partial loading error handling.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Why
The site depended on JavaScript `fetch()` to load navigation and footer partials. If JS or fetch failed, pages could lose navigation or footer content.

## How
- Preserves local fallback HTML before loading partials.
- Keeps fallback content if fetch fails, returns an error, or returns empty content.
- Adds minimal embedded nav/footer fallback in all static pages.
- Logs partial loading issues with `console.warn`.

## Verification
- [x] `npm run ci:test` passes
- [x] Manual review in browser
- [x] No dependency changes
- [x] No breaking changes

## Notes
This keeps the current partials architecture but makes it more resilient.
