### PR TITLE
ci: run lighthouse in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     needs: quality
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,5 +47,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lighthouse CI
+      - name: Lighthouse CI (non-blocking)
         run: npm run ci:lighthouse
+        continue-on-error: true
+
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouseci-reports
+          path: .lighthouseci
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ npm run ci:test
 npm run ci:lighthouse
 ~~~
 
+Nota sobre Windows (`spawn EPERM`):
+- En algunos entornos Windows, `npm run ci:lighthouse` puede fallar localmente al lanzar Chrome en modo headless (`spawn EPERM`).
+- El flujo soportado y estable para Lighthouse es CI en GitHub Actions (`ubuntu-latest`), donde se levanta servidor local (`serve . -l 3000`) y se ejecuta LHCI contra `http://localhost:3000`.
+- Si aparece `EPERM` local, úsalo como señal de entorno local y valida Lighthouse en el job de CI.
+
 ---
 
 ## 🤝 Governance & collaboration

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,12 +1,12 @@
 {
   "ci": {
     "collect": {
-      "startServerCommand": "",
+      "startServerCommand": "npx --yes serve . -l 3000",
       "url": [
-        "https://sergio-site-drab.vercel.app/",
-        "https://sergio-site-drab.vercel.app/about.html",
-        "https://sergio-site-drab.vercel.app/projects.html",
-        "https://sergio-site-drab.vercel.app/contact.html"
+        "http://localhost:3000/",
+        "http://localhost:3000/about.html",
+        "http://localhost:3000/projects.html",
+        "http://localhost:3000/contact.html"
       ],
       "numberOfRuns": 1
     },


### PR DESCRIPTION
## Summary
Adds a GitHub Actions Lighthouse job that runs in Ubuntu against a local static server.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling

## Why
`npm run ci:lighthouse` is unreliable on local Windows due to `spawn EPERM` when launching Chrome. Running Lighthouse in GitHub Actions provides a stable environment and keeps PR quality feedback available.

## How
- Added/updated Lighthouse job in `.github/workflows/ci.yml`
- Configured `lighthouserc.json` to start a local static server
- Audits home, about, projects and contact pages
- Uploads `.lighthouseci` artifacts
- Documents the Windows local `EPERM` behavior in README
- Keeps Lighthouse as non-blocking with `continue-on-error: true`

## Verification
- [x] `npm run ci:test` passes
- [x] Local Lighthouse failure documented as expected on Windows
- [x] No frontend code modified
- [x] No dependency changes

## Notes
`quality` remains the blocking job. Lighthouse currently provides advisory feedback and artifacts without blocking merges.
