### PR TITLE
Expand validation coverage for CRBB case pages

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,9 @@
         "http://localhost:3000/",
         "http://localhost:3000/about.html",
         "http://localhost:3000/projects.html",
-        "http://localhost:3000/contact.html"
+        "http://localhost:3000/contact.html",
+        "http://localhost:3000/case-crbb-pipeline.html",
+        "http://localhost:3000/case-crbb-participantes.html"
       ],
       "numberOfRuns": 1
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npx --yes serve .",
-    "lint:html": "html-validate index.html about.html projects.html contact.html",
+    "lint:html": "html-validate index.html about.html projects.html contact.html case-crbb-pipeline.html case-crbb-participantes.html",
     "check:sitemap": "node scripts/check-sitemap.mjs",
     "ci:test": "npm run lint:html && npm run check:sitemap",
     "ci:lighthouse": "lhci autorun"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -30,4 +30,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://sergio-site-drab.vercel.app/case-crbb-participantes.html</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Include CRBB case pages in HTML validation.
- Add case-crbb-participantes.html to sitemap.
- Extend Lighthouse coverage to CRBB case pages.

## Validation
- cmd /c npm run ci:test