### PR TITLE
Refactor about page professional positioning

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Sobre Sergio Delgado: Ingeniero Civil Industrial enfocado en QA Automation, Data (Python/SQL), CI/CD y transformación digital con IA aplicada.">
+  <meta name="description" content="Sobre Sergio Delgado: Ingeniero Civil Industrial con más de 25 años en infraestructura, sistemas complejos, datos, automatización, validación técnica e IA aplicada.">
   <title>Sobre mí — Sergio Delgado</title>
   <link rel="canonical" href="https://sergio-site-drab.vercel.app/about.html">
-  <meta property="og:title" content="Sobre Sergio Delgado — QA, Datos y Sistemas">
-  <meta property="og:description" content="Perfil profesional de Sergio Delgado en QA, datos y transformación digital.">
+  <meta property="og:title" content="Sobre Sergio Delgado — Ingeniería, Datos y Sistemas Complejos">
+  <meta property="og:description" content="Perfil profesional senior en infraestructura, operación, validación técnica, automatización, datos, IA aplicada y transformación digital.">
   <meta property="og:url" content="https://sergio-site-drab.vercel.app/about.html">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
@@ -32,31 +32,36 @@
     <h1>Sobre mí</h1>
 
     <p>
-      Soy <strong>Ingeniero Civil Industrial</strong> con más de 25 años de experiencia en validación técnica, mejora de procesos y gestión de sistemas complejos.
-      Hoy estoy enfocado en <strong>QA Automation</strong> y <strong>Data Automation</strong>: pruebas UI/API, scripting con Python/SQL y pipelines de CI/CD.
+      Soy <strong>Ingeniero Civil Industrial</strong> con más de 25 años de experiencia en infraestructura, operación, validación técnica,
+      gestión de proyectos, mejora continua y sistemas complejos.
+    </p>
+
+    <p>
+      Trabajo en la intersección entre ingeniería, datos, automatización e <strong>IA aplicada</strong>, con foco en transformar procesos reales
+      en sistemas trazables, medibles y sostenibles para operación, control y toma de decisiones.
     </p>
 
     <p>
       Actualmente desempeño el rol de <strong>Jefe de Transformación Digital y Sistemas de Datos</strong> en la Asociación Gremial Resonancias del Biobío (AG RBB),
-      donde diseño arquitectura digital, automatizo flujos con APIs y construyo indicadores para monitoreo y toma de decisiones.
+      donde diseño gobernanza digital, arquitectura de datos, automatización de flujos e indicadores para monitoreo, trazabilidad y mejora continua.
     </p>
 
     <p>
-      También desarrollo <em>Vida y Muerte de Xexe Quantum</em>, un universo narrativo techno-filosófico que funciona como laboratorio conceptual para pensar identidad,
+      Como línea conceptual secundaria, desarrollo <em>Vida y Muerte de Xexe Quantum</em>, un universo narrativo techno-filosófico para explorar identidad,
       memoria, muerte y resonancia en clave posthumana.
     </p>
 
     <h2>En qué estoy trabajando ahora</h2>
     <ul>
-      <li>Automatización de pruebas (Cypress, Postman/Newman) y prácticas de QA para proyectos reales.</li>
-      <li>Automatización y análisis de datos con Python/SQL, validación y reportabilidad.</li>
-      <li>Flujos y gobernanza digital en AG RBB: métricas, trazabilidad y mejora continua.</li>
+      <li>Gobernanza digital, datos e indicadores en AG RBB, con foco en trazabilidad, operación y toma de decisiones.</li>
+      <li>Automatización y análisis de datos con Python/SQL para validación, reportabilidad y mejora de procesos.</li>
+      <li>QA Automation y validación técnica como capacidad de control para sistemas, flujos y productos digitales.</li>
     </ul>
 
-    <h2>Qué roles busco</h2>
+    <h2>Ámbitos de colaboración</h2>
     <p>
-      Busco roles <strong>QA Automation</strong>, <strong>Data Automation</strong> o <strong>Data Ops (Jr)</strong>,
-      donde aportar criterio de ingeniería, disciplina de validación y enfoque práctico orientado a resultados.
+      Colaboro en arquitectura de datos y automatización, <strong>QA Automation</strong> y validación técnica, transformación digital aplicada,
+      gobernanza de datos e indicadores, y sistemas para infraestructura, agua, cultura y operación.
     </p>
   </main>
 


### PR DESCRIPTION
## Summary
- Reposition About page around senior engineering, systems, data and automation.
- Reduce excessive QA-centric framing.
- Replace junior role-seeking language with collaboration areas.
- Keep Xexe Quantum as a secondary conceptual line.

## Validation
- npm run ci:test
